### PR TITLE
feat(amqp): allow an incomplete URL as parameter

### DIFF
--- a/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
+++ b/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
@@ -4,6 +4,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +25,9 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
     private String port;
     private String username;
     private String password;
-    private String virtualHost;
+
+    @Builder.Default
+    private String virtualHost = "/";
 
     public ConnectionFactory connectionFactory(RunContext runContext) throws Exception {
         if (url != null) {
@@ -47,12 +50,16 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
         URI amqpUri = new URI(runContext.render(url));
 
         host = amqpUri.getHost();
-        port = String.valueOf(amqpUri.getPort());
+        if (amqpUri.getPort() != -1) {
+            port = String.valueOf(amqpUri.getPort());
+        }
 
         String auth = amqpUri.getUserInfo();
-        int pos = auth.indexOf(':');
-        username = pos > 0 ? auth.substring(0, pos) : auth;
-        password = pos > 0 ? auth.substring(pos + 1) : "";
+        if (auth != null) {
+            int pos = auth.indexOf(':');
+            username = pos > 0 ? auth.substring(0, pos) : auth;
+            password = pos > 0 ? auth.substring(pos + 1) : "";
+        }
 
         if (!amqpUri.getPath().equals("")) {
             virtualHost = amqpUri.getPath();

--- a/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
+++ b/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
@@ -4,7 +4,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
-import lombok.Builder;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,9 +25,7 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
     private String port;
     private String username;
     private String password;
-
-    @Builder.Default
-    private String virtualHost = "/";
+    private String virtualHost;
 
     public ConnectionFactory connectionFactory(RunContext runContext) throws Exception {
         if (url != null) {
@@ -35,11 +33,11 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
         }
 
         ConnectionFactory factory = new ConnectionFactory();
-        factory.setHost(runContext.render(host));
-        factory.setPort(Integer.parseInt(runContext.render(port)));
-        factory.setUsername(runContext.render(username));
-        factory.setPassword(runContext.render(password));
-        factory.setVirtualHost(runContext.render(virtualHost));
+        Optional.ofNullable(runContext.render(host)).ifPresent(factory::setHost);
+        Optional.ofNullable(runContext.render(port)).map(Integer::parseInt).ifPresent(factory::setPort);
+        Optional.ofNullable(runContext.render(username)).ifPresent(factory::setUsername);
+        Optional.ofNullable(runContext.render(password)).ifPresent(factory::setPassword);
+        Optional.ofNullable(runContext.render(virtualHost)).ifPresent(factory::setVirtualHost);
 
         factory.setExceptionHandler(new AmqpExceptionHandler(runContext.logger()));
 
@@ -61,7 +59,7 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
             password = pos > 0 ? auth.substring(pos + 1) : "";
         }
 
-        if (!amqpUri.getPath().equals("")) {
+        if (!amqpUri.getPath().isEmpty()) {
             virtualHost = amqpUri.getPath();
         }
     }

--- a/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
+++ b/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
@@ -28,6 +28,9 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
     private String virtualHost;
 
     public ConnectionFactory connectionFactory(RunContext runContext) throws Exception {
+        if (url != null && host != null) {
+            throw new IllegalArgumentException("Cannot define both `url` and `host`");
+        }
         if (url != null) {
             parseFromUrl(runContext, url);
         }

--- a/src/test/java/io/kestra/plugin/amqp/AMQPTest.java
+++ b/src/test/java/io/kestra/plugin/amqp/AMQPTest.java
@@ -81,10 +81,9 @@ class AMQPTest {
     }
 
     @Test
-    void createConnectionFactoryWithUriAndFields() throws Exception {
+    void createConnectionFactoryWithUriAndFieldsButNoHost() throws Exception {
         Publish push = Publish.builder()
-                .url("amqp://example.org") // values extracted from the URI are considered first
-                .host("ignore.it")
+                .url("amqp://example.org")
                 .port("12345")
                 .username("kestra")
                 .password("K3str4")
@@ -97,6 +96,16 @@ class AMQPTest {
         assertThat(connectionFactory.getUsername(), is("kestra"));
         assertThat(connectionFactory.getPassword(), is("K3str4"));
         assertThat(connectionFactory.getVirtualHost(), is("/my_vhost"));
+    }
+
+    @Test
+    void createConnectionFactoryWithUriAndHostBothDefined() {
+        Publish push = Publish.builder()
+                .url("amqp://example.org")
+                .host("ignore.it")
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> push.connectionFactory(runContextFactory.of()));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/amqp/AMQPTest.java
+++ b/src/test/java/io/kestra/plugin/amqp/AMQPTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.amqp;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.collect.ImmutableMap;
+import com.rabbitmq.client.ConnectionFactory;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
@@ -21,8 +22,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -36,6 +35,69 @@ class AMQPTest {
 
     @Inject
     protected StorageInterface storageInterface;
+
+    @Test
+    void createConnectionFactoryWithDefaultValues() throws Exception {
+        Publish push = Publish.builder().build();
+
+        ConnectionFactory connectionFactory = push.connectionFactory(runContextFactory.of());
+        assertThat(connectionFactory.getHost(), is(ConnectionFactory.DEFAULT_HOST));
+        assertThat(connectionFactory.getPort(), is(ConnectionFactory.DEFAULT_AMQP_PORT));
+        assertThat(connectionFactory.getUsername(), is(ConnectionFactory.DEFAULT_USER));
+        assertThat(connectionFactory.getPassword(), is(ConnectionFactory.DEFAULT_PASS));
+        assertThat(connectionFactory.getVirtualHost(), is(ConnectionFactory.DEFAULT_VHOST));
+    }
+
+    @Test
+    void createConnectionFactoryWithUriOnly() throws Exception {
+        Publish push = Publish.builder()
+                .url("amqp://kestra:K3str4@example.org:12345/my_vhost")
+                .build();
+
+        ConnectionFactory connectionFactory = push.connectionFactory(runContextFactory.of());
+        assertThat(connectionFactory.getHost(), is("example.org"));
+        assertThat(connectionFactory.getPort(), is(12345));
+        assertThat(connectionFactory.getUsername(), is("kestra"));
+        assertThat(connectionFactory.getPassword(), is("K3str4"));
+        assertThat(connectionFactory.getVirtualHost(), is("/my_vhost"));
+    }
+
+    @Test
+    void createConnectionFactoryWithFieldsOnly() throws Exception {
+        Publish push = Publish.builder()
+                .host("example.org")
+                .port("12345")
+                .username("kestra")
+                .password("K3str4")
+                .virtualHost("/my_vhost")
+                .build();
+
+        ConnectionFactory connectionFactory = push.connectionFactory(runContextFactory.of());
+        assertThat(connectionFactory.getHost(), is("example.org"));
+        assertThat(connectionFactory.getPort(), is(12345));
+        assertThat(connectionFactory.getUsername(), is("kestra"));
+        assertThat(connectionFactory.getPassword(), is("K3str4"));
+        assertThat(connectionFactory.getVirtualHost(), is("/my_vhost"));
+    }
+
+    @Test
+    void createConnectionFactoryWithUriAndFields() throws Exception {
+        Publish push = Publish.builder()
+                .url("amqp://example.org") // values extracted from the URI are considered first
+                .host("ignore.it")
+                .port("12345")
+                .username("kestra")
+                .password("K3str4")
+                .virtualHost("/my_vhost")
+                .build();
+
+        ConnectionFactory connectionFactory = push.connectionFactory(runContextFactory.of());
+        assertThat(connectionFactory.getHost(), is("example.org"));
+        assertThat(connectionFactory.getPort(), is(12345));
+        assertThat(connectionFactory.getUsername(), is("kestra"));
+        assertThat(connectionFactory.getPassword(), is("K3str4"));
+        assertThat(connectionFactory.getVirtualHost(), is("/my_vhost"));
+    }
 
     @Test
     void pushAsList() throws Exception {


### PR DESCRIPTION
The main goal of these changes is to allow the definition of credentials from a secret manager. The URL can stay clear in K8s configuration, and credentials are often split as a key/value pair.