### PR TITLE
docs(amqp): update trigger examples

### DIFF
--- a/src/main/java/io/kestra/plugin/amqp/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/amqp/RealtimeTrigger.java
@@ -62,7 +62,11 @@ import java.util.concurrent.atomic.AtomicReference;
                 triggers:
                   - id: realtime_trigger
                     type: io.kestra.plugin.amqp.RealtimeTrigger
-                    url: amqp://guest:guest@localhost:5672/my_vhost
+                    host: localhost
+                    port: 5672
+                    username: guest
+                    password: guest
+                    virtualHost: /my_vhost
                     queue: amqpTrigger.queue
                 """
         )

--- a/src/main/java/io/kestra/plugin/amqp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/amqp/Trigger.java
@@ -37,7 +37,11 @@ import java.util.Optional;
                 tasks:
                   - id: trigger
                     type: io.kestra.plugin.amqp.Trigger
-                    url: amqp://guest:guest@localhost:5672/my_vhost
+                    host: localhost
+                    port: 5672
+                    username: guest
+                    password: guest
+                    virtualHost: /my_vhost
                     maxRecords: 2
                     queue: amqpTrigger.queue
                 """


### PR DESCRIPTION
Part of https://github.com/kestra-io/plugin-amqp/issues/80

It looks like Host is now required and URI is deprecated so let's also update the examples to use the required property.