### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
+++ b/src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java
@@ -10,6 +10,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -32,6 +33,8 @@ public abstract class AbstractAmqpConnection extends Task implements AmqpConnect
 
     private Property<String> username;
 
+    @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> password;
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/amqp/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/amqp/RealtimeTrigger.java
@@ -76,6 +76,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private Property<String> username;
 
+    @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> password;
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/amqp/Trigger.java
+++ b/src/main/java/io/kestra/plugin/amqp/Trigger.java
@@ -67,6 +67,8 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
 
     private Property<String> username;
 
+    @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> password;
 
     @Builder.Default


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Password field exposed by Lombok @ToString in AbstractAmqpConnection, Trigger, and RealtimeTrigger (`src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java:18`)
  - Fix: Added `@ToString.Exclude` on the `password` field in AbstractAmqpConnection, Trigger, and RealtimeTrigger to prevent the cleartext password from being emitted in logs or stack traces via Lombok-generated `toString()`.

- **MEDIUM** Password field re-declared in concrete classes without @PluginProperty(secret=true) on the field itself (`src/main/java/io/kestra/plugin/amqp/AbstractAmqpConnection.java:35`)
  - Fix: Added `@PluginProperty(secret = true, group = "connection")` directly on the `password` field in AbstractAmqpConnection, Trigger, and RealtimeTrigger to ensure the secret flag is picked up regardless of whether the framework uses field or getter reflection.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-amqp/issues/164
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
