### PR TITLE
Documentation review: plugin-amqp

### DIFF
--- a/src/main/java/io/kestra/plugin/amqp/Consume.java
+++ b/src/main/java/io/kestra/plugin/amqp/Consume.java
@@ -70,6 +70,7 @@ import io.kestra.core.models.annotations.PluginProperty;
         @Metric(
             name = "consumed.records",
             type = Counter.TYPE,
+            unit = "records",
             description = "The total number of records consumed from the AMQP queue."
         )
     }
@@ -347,7 +348,7 @@ public class Consume extends AbstractAmqpConnection implements RunnableTask<Cons
 
         @Schema(
             title = "URI of file storing consumed messages",
-            description = "Internal storage path to the Ion-serialized batch returned as `taskrun.outputs.uri` or `trigger.uri`."
+            description = "Internal storage path to the ION-serialized batch returned as `taskrun.outputs.uri` or `trigger.uri`."
         )
         private final URI uri;
     }


### PR DESCRIPTION
## Documentation review: plugin-amqp

Documentation-only pass over all 7 tasks/triggers (`Publish`, `Consume`, `CreateQueue`,
`DeclareExchange`, `QueueBind`, `Trigger`, `RealtimeTrigger`), the connection/consume interfaces,
the `Message`/`SerdeType` models, the plugin how-to doc, and metadata. Task inventory cross-checked
against the Kestra plugin registry (5 tasks + 2 triggers, matches). No behavior, validation, or
UI-layout changes.

The plugin was already in excellent shape (valid examples, all declared metrics emitted, every
`Message` output field documented, accurate doc/metadata). Two minor fixes only:

- **`Consume.Output.uri`:** "Ion-serialized" → "ION-serialized" (file-type acronym uppercased).
- **`Consume` `consumed.records` metric:** added `unit = "records"` for parity with the sibling
  `Publish` `published.records` metric (descriptive only; does not change emission).
