### PR TITLE
fix(tests): de-flake RealtimeTriggerTest by counting distinct executions

### DIFF
--- a/src/test/java/io/kestra/plugin/amqp/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/amqp/RealtimeTriggerTest.java
@@ -1,8 +1,12 @@
 package io.kestra.plugin.amqp;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,12 +22,23 @@ import static org.hamcrest.Matchers.is;
 class RealtimeTriggerTest extends AbstractTriggerTest {
     @Test
     void flow() throws Exception {
+        // the execution queue emits one message per execution state change, so both the latch and the
+        // assertions are based on distinct execution identifiers instead of the raw message count
+        Set<String> executionIds = ConcurrentHashMap.newKeySet();
         CountDownLatch queueCount = new CountDownLatch(4);
 
-        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution ->
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, either ->
         {
-            queueCount.countDown();
-            assertThat(execution.getLeft().getFlowId(), is("realtime"));
+            if (either.isRight()) {
+                return;
+            }
+
+            Execution execution = either.getLeft();
+            assertThat(execution.getFlowId(), is("realtime"));
+
+            if (executionIds.add(execution.getId())) {
+                queueCount.countDown();
+            }
         });
 
         this.run("realtime.yaml", throwRunnable(() ->
@@ -33,10 +48,20 @@ class RealtimeTriggerTest extends AbstractTriggerTest {
 
             boolean await = queueCount.await(1, TimeUnit.MINUTES);
             assertThat(await, is(true));
-            List<Execution> executionList = receive.collectList().block();
+            Collection<Execution> executions = distinctExecutions(receive);
 
-            assertThat(executionList.size(), is(4));
-            assertThat(executionList.stream().filter(execution -> execution.getTrigger().getVariables().get("data").equals("value-2")).count(), is(2L));
+            assertThat(executions.size(), is(4));
+            assertThat(executions.stream().filter(execution -> execution.getTrigger().getVariables().get("data").equals("value-2")).count(), is(2L));
         }));
+    }
+
+    /**
+     * Collects the buffered execution messages, keeping the latest message of each execution.
+     */
+    private Collection<Execution> distinctExecutions(Flux<Execution> receive) {
+        return receive.collectList().block()
+            .stream()
+            .collect(Collectors.toMap(Execution::getId, execution -> execution, (first, last) -> last, LinkedHashMap::new))
+            .values();
     }
 }


### PR DESCRIPTION
## What

`RealtimeTriggerTest.flow()` failed on the `v1.5.6` release build of `main` ([run 30548076084](https://github.com/kestra-io/plugin-amqp/actions/runs/30548076084/job/90889295785)):

```
java.lang.AssertionError:
Expected: is <4>
     but: was <5>
	at io.kestra.plugin.amqp.RealtimeTriggerTest.lambda$flow$2(RealtimeTriggerTest.java:38)
```

## Why

The plugin is fine — the test was racy.

`TestsUtils.receive` buffers **every** message it observes on the queue into a list. On subscribe, `collectList()` drains that buffer into the sink and completes immediately:

```
12: aload_1              // buffered list
19: invokedynamic ...    // forEach -> sink.next
30: invokeinterface FluxSink.complete()
```

The execution queue emits one message *per execution state change*, not one per execution. So `executionList.size()` was really "how many queue messages happened to be buffered at the instant we collected". The `CountDownLatch(4)` did not bound it either, since it also counted down on every message.

Measured locally by sleeping 5s after the latch so every transition is definitely buffered: **24 messages for the 4 expected executions**. The old assertion passed only when it won the race against message #5. In the CI run the executions' `end` tasks were already starting at 13:43:16.040–16.464 while the assertion ran at 13:43:16.25 — it lost by milliseconds.

## How

Track distinct execution ids, for both the latch and the assertions:

- the latch counts down only on the *first* message seen per execution id, so awaiting it now genuinely means "4 distinct executions arrived";
- the collected messages are deduplicated by execution id, keeping the latest message per execution, before asserting on the count and on the `value-2` trigger variable.

This is strictly stronger than before: previously the latch could release after seeing only 2 executions (if each had already emitted 2 state changes).

Also skips `Either` right values instead of calling `getLeft()` unconditionally.

## Verification

- `./gradlew check` — 21/21 tests pass.
- `RealtimeTriggerTest` run 6× consecutively with `--rerun-tasks` — green every time.
- With a 5s sleep forced before collection (worst case for the old code, guaranteeing all 24 messages are buffered), the new assertions still pass while the old message-count assertion fails with `but: was <24>`.

## Note

`realtime.yaml` and `trigger.yaml` both consume the shared `amqpTrigger.queue`, so leftover messages between test classes remain a theoretical source of extra executions. That is not what broke this run and is left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
